### PR TITLE
Use ActiveSupport.on_load hook instead of eagerly loading external dependencies

### DIFF
--- a/lib/redshift_cursor.rb
+++ b/lib/redshift_cursor.rb
@@ -1,8 +1,12 @@
 require 'redshift_cursor/version'
-require 'redshift_cursor/active_record/connection_adapters/redshift_type_map'
 
-require 'postgresql_cursor'
+require 'active_support'
 
-require 'active_record'
-require 'active_record/connection_adapters/redshift_adapter'
-ActiveRecord::ConnectionAdapters::RedshiftAdapter.send(:include, RedshiftCursor::ActiveRecord::ConnectionAdapters::RedshiftTypeMap)
+ActiveSupport.on_load :active_record do
+  require 'redshift_cursor/active_record/connection_adapters/redshift_type_map'
+
+  require 'postgresql_cursor'
+
+  require 'active_record/connection_adapters/redshift_adapter'
+  ActiveRecord::ConnectionAdapters::RedshiftAdapter.send(:include, RedshiftCursor::ActiveRecord::ConnectionAdapters::RedshiftTypeMap)
+end


### PR DESCRIPTION
Current implementation of redshift_cursor immediately starts loading everything when the gem is loaded, but this behavior is against Rails' convention, and sometimes causes weird problems on Rails apps.

The actual problem I hit today was this: https://github.com/afair/postgresql_cursor/issues/41
redshift_cursor immediately loads postgresql_cursor when being bundled via bundler, then postgresql_cursor expects the connection adapter to be loaded already
https://github.com/afair/postgresql_cursor/blob/92224ba/lib/postgresql_cursor/cursor.rb#L27,
but the connection adapters tend not to be loaded here yet since Rails usually loads the connection adapters ___after___ loading `config/database.rb` and determines which connection adapter to load.

This PR introduces `ActiveSupport.on_load` hook mechanism that enables us to load things lazily until we actually start loading AR models and gets ready to connect to the DBs.
This hook mechanism itself is implemented in Active Support and so it should work independently on Rails (Railties). The hook has to be triggered via `ActiveSupport.run_load_hooks` in a proper timing, and in most cases on actual Rails apps, it's done within `AR::Base` class here https://github.com/rails/rails/blob/35a0fba187dc6a09d9f61336152158da238da444/activerecord/lib/active_record/base.rb#L327.